### PR TITLE
Syntax error at ':'; expected '}' at /etc/puppet/modules/btsync/manifests/shared_folder.pp:130

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 pkg/
 *.swp
+.librarian/
+.tmp/
+spec/fixtures/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+group :rake do
+  gem 'puppet'
+  gem 'rspec-puppet'
+  gem 'rake'
+  gem 'puppetlabs_spec_helper'
+  gem 'puppet-blacksmith'
+  gem 'librarian-puppet-maestrodev'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,64 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.4)
+    facter (1.7.2)
+    hiera (1.2.1)
+      json_pure
+    highline (1.6.19)
+    json (1.8.0)
+    json_pure (1.8.0)
+    librarian (0.1.0)
+      highline
+      thor (~> 0.15)
+    librarian-puppet-maestrodev (0.9.9.8)
+      json
+      librarian (>= 0.1.0)
+    metaclass (0.0.1)
+    mime-types (1.23)
+    mini_portile (0.5.1)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    puppet (3.2.3)
+      facter (~> 1.6)
+      hiera (~> 1.0)
+      rgen (~> 0.6.5)
+    puppet-blacksmith (1.0.5)
+      nokogiri
+      puppet (>= 2.7.16)
+      puppetlabs_spec_helper (>= 0.3.0)
+      rake
+      rest-client
+    puppetlabs_spec_helper (0.4.1)
+      mocha (>= 0.10.5)
+      rake
+      rspec (>= 2.9.0)
+      rspec-puppet (>= 0.1.1)
+    rake (10.1.0)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    rgen (0.6.5)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.4)
+    rspec-expectations (2.14.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.2)
+    rspec-puppet (0.1.6)
+      rspec
+    thor (0.18.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  librarian-puppet-maestrodev
+  puppet
+  puppet-blacksmith
+  puppetlabs_spec_helper
+  rake
+  rspec-puppet

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,5 @@
+forge 'http://forge.puppetlabs.com'
+
+mod 'puppetlabs/stdlib'
+mod 'puppetlabs/apt'
+mod 'theforeman/concat_native'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,0 +1,13 @@
+FORGE
+  remote: http://forge.puppetlabs.com
+  specs:
+    puppetlabs/apt (1.2.0)
+      puppetlabs/stdlib (>= 2.2.1)
+    puppetlabs/stdlib (4.1.0)
+    theforeman/concat_native (1.2.0)
+
+DEPENDENCIES
+  puppetlabs/apt (>= 0)
+  puppetlabs/stdlib (>= 0)
+  theforeman/concat_native (>= 0)
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,20 @@
+require 'bundler'
+Bundler.require(:rake)
+require 'rake/clean'
+
+CLEAN.include('spec/fixtures/', 'doc', 'pkg')
+CLOBBER.include('.tmp', '.librarian')
+
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet_blacksmith/rake_tasks'
+
+# use librarian-puppet to manage fixtures instead of .fixtures.yml
+# offers more possibilities like explicit version management, forge
+# downloads,...
+task :librarian_spec_prep do
+  sh "librarian-puppet install --path=spec/fixtures/modules/"
+  File.symlink("../../..", "spec/fixtures/modules/btsync")
+end
+task :spec_prep => :librarian_spec_prep
+
+task :default => [:clean, :spec]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'btsync' do
+
+  context "default parameters" do
+    it { should contain_class('btsync::config') }
+    it { should contain_class('btsync::install') }
+    it { should contain_class('btsync::service') }
+  end
+
+  context "with webui" do
+    let(:params) {{
+      :instances => {
+        :btsync => {
+          :storage_path => '/home/btsync/.sync',
+          :webui        => {
+            :listen   => '0.0.0.0:8888',
+            :login    => 'btsync',
+            :password => 'password',
+          }
+        }
+      }  
+    }}
+
+    it { should contain_class('btsync::config') }
+    it { should contain_class('btsync::install') }
+    it { should contain_class('btsync::service') }
+    it { should contain_btsync__instance('btsync') }
+  end
+end

--- a/spec/classes/shared_folder_spec.rb
+++ b/spec/classes/shared_folder_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'btsync::shared_folder' do
+
+  context "default parameters" do
+    it { should contain_btsync__known_host('') }
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+
+  c.before(:each) do
+    Puppet::Util::Log.level = :warning
+    Puppet::Util::Log.newdestination(:console)
+  end
+
+end


### PR DESCRIPTION
I'm getting this error with a simple 

```
  include btsync::repo
  include btsync
  btsync::instance { 'yyy':
    device_name => 'xxx',
    storage_path => '/home/yyy/.sync',
  }
```

so I added some specs that you can run with `rake` that give the same error
