### PR TITLE
Fix for Puppet 3.7 + future parser

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -14,7 +14,7 @@
 class btsync::repo {
   include ::apt
   case $::operatingsystem {
-    Debian: {
+    'Debian': {
       apt::source { 'btsync':
         location          => 'http://debian.yeasoft.net/btsync',
         release           => $::lsbdistcodename,
@@ -25,7 +25,7 @@ class btsync::repo {
         include_src       => true,
       }
     }
-    Ubuntu: {
+    'Ubuntu': {
       apt::ppa { 'ppa:tuxpoldo/btsync': }
     }
     default: {


### PR DESCRIPTION
Puppet 3.7 + future parser doesn't match operatingsystem without quoting the comparison as a string.

\# puppet --version
3.7.2

\# grep "parser" /etc/puppet/puppet.conf
    parser = future

\# facter -p operatingsystem
Ubuntu

Before this change:
Error: Unsupported Operating System: Ubuntu on node ...