### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Public name of the device. Defaults to $name.
 Port the daemon listen to. Defaults to 0 (random port).
 
 ####`storage_path`
-storage_path dir contains auxilliary app files if no storage_path field: .sync dir created in the directory where binary is located.
+storage_path dir contains auxiliary app files if no storage_path field: .sync dir created in the directory where binary is located.
 
 ####`pid_file`
 Override location of pid file.


### PR DESCRIPTION
mcanevet, I've corrected a typographical error in the documentation of the [puppet-btsync](https://github.com/mcanevet/puppet-btsync) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.